### PR TITLE
Fix/section-h-sizes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -70,7 +70,7 @@ function App() {
         <Route
           path="/"
           element={
-            <main className="pt-16">
+            <main className="pt-16 lg:pl-28 xl:pl-36">
               <section
                 id="home"
                 className="min-h-screen flex items-center justify-center"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,31 +73,31 @@ function App() {
             <main className="pt-16">
               <section
                 id="home"
-                className="h-screen flex items-center justify-center"
+                className="min-h-screen flex items-center justify-center"
               >
                 <Hero />
               </section>
               <section
                 id="about"
-                className="h-screen flex items-center justify-center"
+                className="min-h-screen flex items-center justify-center"
               >
                 <About />
               </section>
               <section
                 id="projects"
-                className="h-screen flex items-center justify-center"
+                className="min-h-screen flex items-center justify-center"
               >
                 <Projects />
               </section>
               <section
                 id="experience"
-                className="h-screen flex items-center justify-center"
+                className="min-h-screen flex items-center justify-center"
               >
                 <Experience />
               </section>
               <section
                 id="contact"
-                className="h-screen flex items-center justify-center"
+                className="min-h-screen flex items-center justify-center"
               >
                 <Contact />
               </section>

--- a/src/sections/About.tsx
+++ b/src/sections/About.tsx
@@ -14,7 +14,10 @@ export const About = () => {
 
   return (
     <section id="about" className="container py-24 max-w-6xl mx-auto">
-      <SectionTitle title="About Me" />
+      {/* Section Title */}
+      <h2 className="text-4xl font-bold text-accent mb-16 text-center">
+        About Me
+      </h2>
 
       <div className="flex flex-col md:flex-row gap-12 md:gap-20">
         {/* Left Column: About Text */}

--- a/src/sections/Contact.tsx
+++ b/src/sections/Contact.tsx
@@ -41,7 +41,7 @@ export const Contact = () => {
   };
 
   return (
-    <section id="contact" className="container py-24 max-w-6xl mx-auto">
+    <section id="contact" className="container py-24 max-w-6xl mx-auto pt-2">
       {/* SEO Meta */}
       <Helmet>
         <title>Contact | Your Name</title>

--- a/src/sections/Projects.tsx
+++ b/src/sections/Projects.tsx
@@ -5,7 +5,10 @@ import { projects } from "../data/projects";
 export const Projects = () => {
   return (
     <section id="projects" className="container py-24 max-w-6xl mx-auto">
-      <SectionTitle title="Projects" />
+      {/* Section Title */}
+      <h2 className="text-4xl font-bold text-accent mb-16 text-center">
+        Projects
+      </h2>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
         {projects.map((project, index) => (

--- a/src/sections/Sidebar.tsx
+++ b/src/sections/Sidebar.tsx
@@ -13,7 +13,8 @@ export const Sidebar = ({ activeSection }: SidebarProps) => {
       animate={{ x: 0, opacity: 1 }}
       exit={{ x: -100, opacity: 0 }}
       transition={{ duration: 0.4 }}
-      className="hidden md:fixed md:flex flex-col items-start gap-6 top-1/4 left-8 z-50"
+      className="hidden lg:fixed lg:flex flex-col items-start gap-6 top-1/4 left-6 lg:left-10 xl:left-16 z-50"
+
     >
       {navLinks.map((link) => (
         <NavbarLink


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Description

> What changes have you made? (Short summary)

- Fixed layout issues where the Contact section overlapped other sections
- Replaced `h-screen` with `min-h-screen` for all sections to prevent overflow
- Adjusted `Sidebar` spacing with responsive `left-*` and limited display to `lg+`
- Added responsive left padding to `<main>` for consistent layout when sidebar appears

---

## 📂 Type of change

> Select one:

- [x] Bug fix (fix a problem)
- [ ] New feature (add functionality)
- [ ] Refactor (improve code without changing functionality)
- [x] UI improvement
- [ ] Documentation update
- [ ] Other (please describe):

---

## 🧪 How to test

> Explain how reviewers can test this feature.

- Visit the site and scroll through all sections — no overlapping should occur
- Resize to different widths (including 1200px and below)
- Confirm the sidebar no longer overlaps content
- Confirm layout consistency and section spacing

---

## 📌 Checklist

- [x] I have tested my changes manually
- [x] I have updated related documentation if needed
- [x] My code follows the project's style guidelines
- [x] I have no console errors or warnings
- [x] I have added useful comments if needed

---

## 📝 Additional notes (optional)

> Anything else important to mention? (Screenshots, links, context)

- This resolves the layout issues previously affecting 1030px and mobile widths
- Ready to begin `feature/mobile-navigation` in a clean branch
